### PR TITLE
Fix log file creation in refresh_GIT.sh

### DIFF
--- a/refresh_GIT.sh
+++ b/refresh_GIT.sh
@@ -46,12 +46,14 @@ workdir="workspace"
 user=`whoami`
 timeRightNow=`date +%Y%m%d`
 loggerFile="refreshGIT_logs/_refreshGIT_Log_$timeRightNow.log"
-> $loggerFile
+mkdir -p "$(dirname "$loggerFile")"
+> "$loggerFile"
 
 dirArray=("refreshGIT_logs" "sources")
 filesArray=("$source" "$loggerFile")
 
 echo -e "\n Verify the directories :" && verifyDirectory
+
 echo -e "\n Verify the files :" && verifyFile
 echo -e "\n"
 echo -e "\n #A - OKAY for directories and files\n" >>$loggerFile


### PR DESCRIPTION
## Summary
- ensure log directory is created before log file is touched

## Testing
- `bash -n refresh_GIT.sh`


------
https://chatgpt.com/codex/tasks/task_e_68401c7006488324896d3080df7c436d